### PR TITLE
Remove redundant php option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,6 @@ If the `MAUTIC_DB_NAME` specified does not already exist on the given MySQL serv
 -	`-e PHP_MAX_UPLOAD=...` (defaults to `20M`) Set PHP upload max file size
 -	`-e PHP_MAX_EXECUTION_TIME=...` (defaults to `300`) Set PHP max execution time
 
-### PHP options
--	`-e PHP_INI_DATE_TIMEZONE=...` (defaults to `UTC`) Set PHP timezone
--	`-e PHP_MEMORY_LIMIT=...` (defaults to `256M`) Set PHP memory limit
--	`-e PHP_MAX_UPLOAD=...` (defaults to `20M`) Set PHP upload max file size
--	`-e PHP_MAX_EXECUTION_TIME=...` (defaults to `300`) Set PHP max execution time
-
-
 ### Persistent Data Volumes
 
 On first run Mautic is unpacked at `/var/www/html`. You need to attach a volume on this path to persist data.


### PR DESCRIPTION
Update README.md remove redundant PHP options descriptions